### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/brainsait_ocr_app.html
+++ b/brainsait_ocr_app.html
@@ -485,6 +485,16 @@
             }
         }
 
+        // Escape HTML meta-characters to prevent XSS
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         function addFileToQueue(file, index, status) {
             const queueElement = document.getElementById('fileQueue');
             const fileDiv = document.createElement('div');
@@ -499,8 +509,8 @@
                         </svg>
                     </div>
                     <div>
-                        <p class="text-white font-medium">${file.name}</p>
-                        <p class="text-purple-200 text-sm">${formatFileSize(file.size)}</p>
+                        <p class="text-white font-medium">${escapeHtml(file.name)}</p>
+                        <p class="text-purple-200 text-sm">${escapeHtml(formatFileSize(file.size))}</p>
                     </div>
                 </div>
                 <div id="status-${index}" class="flex items-center">

--- a/brainsait_ocr_app.html
+++ b/brainsait_ocr_app.html
@@ -510,7 +510,7 @@
                     </div>
                     <div>
                         <p class="text-white font-medium">${escapeHtml(file.name)}</p>
-                        <p class="text-purple-200 text-sm">${escapeHtml(formatFileSize(file.size))}</p>
+                        <p class="text-purple-200 text-sm">${formatFileSize(file.size)}</p>
                     </div>
                 </div>
                 <div id="status-${index}" class="flex items-center">


### PR DESCRIPTION
Potential fix for [https://github.com/Fadil369/brainsait-ocr/security/code-scanning/2](https://github.com/Fadil369/brainsait-ocr/security/code-scanning/2)

To fix the problem, we must ensure that any untrusted data (such as `file.name`) is properly escaped before being inserted into the DOM as HTML. The best way to do this is to escape HTML meta-characters in `file.name` and any other untrusted values before including them in the template literal for `fileDiv.innerHTML`. This can be done by creating a helper function (e.g., `escapeHtml`) that replaces `<`, `>`, `&`, `"`, and `'` with their corresponding HTML entities. The fix should be applied in the `addFileToQueue` function, specifically where `file.name` and `formatFileSize(file.size)` are interpolated into the HTML string. The helper function should be defined in the same script block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
